### PR TITLE
[#25] 회원 도메인 DTO 분리

### DIFF
--- a/src/main/java/com/flab/auctionhub/user/api/UserController.java
+++ b/src/main/java/com/flab/auctionhub/user/api/UserController.java
@@ -1,11 +1,11 @@
 package com.flab.auctionhub.user.api;
 
 import com.flab.auctionhub.user.application.UserService;
-import com.flab.auctionhub.user.dto.request.UserCreateRequest;
-import com.flab.auctionhub.user.dto.request.UserLoginRequest;
-import com.flab.auctionhub.user.dto.response.UserCreateResponse;
+import com.flab.auctionhub.user.api.request.UserCreateRequest;
+import com.flab.auctionhub.user.api.request.UserLoginRequest;
+import com.flab.auctionhub.user.application.response.UserCreateResponse;
 import java.util.List;
-import com.flab.auctionhub.user.dto.response.UserLoginResponse;
+import com.flab.auctionhub.user.application.response.UserLoginResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,7 +28,7 @@ public class UserController {
     // HTTP POST 요청을 매핑하는 어노테이션이며 @RequestMapping(method = RequestMethod.POST)과 같은 역할을 한다.
     public ResponseEntity<Long> createUser(@RequestBody @Validated UserCreateRequest request) {
         // @RequestBody : 요청의 body 데이터를 객체로 변환해주는 어노테이션, @Validated : 유효성 검증을 적용하기 위해 사용된 어노테이션
-        Long id = userService.createUser(request);
+        Long id = userService.createUser(request.toServiceRequest());
         return new ResponseEntity<>(id, HttpStatus.CREATED);
     }
 
@@ -54,7 +54,7 @@ public class UserController {
     @PostMapping(path = "/login")
     public ResponseEntity<UserLoginResponse> login(@RequestBody @Validated UserLoginRequest request,
         HttpSession session) {
-        UserLoginResponse userLoginResponse = userService.login(request, session);
+        UserLoginResponse userLoginResponse = userService.login(request.toServiceRequest(), session);
         return new ResponseEntity<>(userLoginResponse, HttpStatus.OK);
     }
 

--- a/src/main/java/com/flab/auctionhub/user/api/request/UserCreateRequest.java
+++ b/src/main/java/com/flab/auctionhub/user/api/request/UserCreateRequest.java
@@ -1,6 +1,6 @@
-package com.flab.auctionhub.user.dto.request;
+package com.flab.auctionhub.user.api.request;
 
-import com.flab.auctionhub.user.domain.User;
+import com.flab.auctionhub.user.application.request.UserCreateServiceRequest;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -8,7 +8,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @Builder
@@ -40,13 +39,12 @@ public class UserCreateRequest {
     @Pattern(regexp = "^(010)-\\d{4}-\\d{4}$", message = "휴대폰 번호 형식에 맞게 입력해 주세요.") // 문자열 값이 정규 표현식과 일치하는지를 검증하기 위한 어노테이션
     private String phoneNumber;
 
-    public User toEntity(PasswordEncoder passwordEncoder) {
-        return User.builder()
+    public UserCreateServiceRequest toServiceRequest() {
+        return UserCreateServiceRequest.builder()
             .userId(this.getUserId())
-            .password(passwordEncoder.encode(this.getPassword()))
+            .password(this.getPassword())
             .username(this.getUsername())
             .phoneNumber(this.getPhoneNumber())
-            .createdBy(this.getUsername())
             .build();
     }
 }

--- a/src/main/java/com/flab/auctionhub/user/api/request/UserLoginRequest.java
+++ b/src/main/java/com/flab/auctionhub/user/api/request/UserLoginRequest.java
@@ -1,5 +1,6 @@
-package com.flab.auctionhub.user.dto.request;
+package com.flab.auctionhub.user.api.request;
 
+import com.flab.auctionhub.user.application.request.UserLoginServiceRequest;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,4 +18,12 @@ public class UserLoginRequest {
 
     @NotBlank(message = "비밀번호 입력은 필수입니다.")
     private String password;
+
+    public UserLoginServiceRequest toServiceRequest() {
+        return UserLoginServiceRequest.builder()
+            .userId(this.userId)
+            .password(this.password)
+            .build();
+
+    }
 }

--- a/src/main/java/com/flab/auctionhub/user/application/UserService.java
+++ b/src/main/java/com/flab/auctionhub/user/application/UserService.java
@@ -1,11 +1,11 @@
 package com.flab.auctionhub.user.application;
 
+import com.flab.auctionhub.user.application.request.UserCreateServiceRequest;
+import com.flab.auctionhub.user.application.request.UserLoginServiceRequest;
+import com.flab.auctionhub.user.application.response.UserCreateResponse;
+import com.flab.auctionhub.user.application.response.UserLoginResponse;
 import com.flab.auctionhub.user.dao.UserMapper;
 import com.flab.auctionhub.user.domain.User;
-import com.flab.auctionhub.user.dto.request.UserCreateRequest;
-import com.flab.auctionhub.user.dto.request.UserLoginRequest;
-import com.flab.auctionhub.user.dto.response.UserCreateResponse;
-import com.flab.auctionhub.user.dto.response.UserLoginResponse;
 import com.flab.auctionhub.user.exception.DuplicatedUserIdException;
 import com.flab.auctionhub.user.exception.InvalidSigningInformationException;
 import com.flab.auctionhub.user.exception.UserNotFoundException;
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service // 서비스 레이어임을 명시해주며 @Component를 가지고 있어 스프링 빈으로 등록 시키는 역할을 수행한다.
+@Transactional(readOnly = true) // readOnly = true : 읽기 전용, CRUD에서 CUD 동작X / only Read
 @RequiredArgsConstructor
 public class UserService {
 
@@ -27,7 +28,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional // 수행하는 작업에 대해 트랜잭션 원칙이 지켜지도록 보장해주는 역할을 한다.
-    public Long createUser(UserCreateRequest request) {
+    public Long createUser(UserCreateServiceRequest request) {
         this.checkUserIdDuplication(request.getUserId());
         User user = request.toEntity(passwordEncoder);
         userMapper.save(user);
@@ -52,7 +53,7 @@ public class UserService {
             .orElseThrow(() -> new UserNotFoundException("해당 유저를 찾을 수 없습니다."));
     }
 
-    public UserLoginResponse login(UserLoginRequest request, HttpSession session) {
+    public UserLoginResponse login(UserLoginServiceRequest request, HttpSession session) {
         User user = userMapper.findByUserId(request.getUserId())
             .orElseThrow(() -> new InvalidSigningInformationException("등록 되지 않은 사용자입니다."));
 

--- a/src/main/java/com/flab/auctionhub/user/application/request/UserCreateServiceRequest.java
+++ b/src/main/java/com/flab/auctionhub/user/application/request/UserCreateServiceRequest.java
@@ -1,0 +1,42 @@
+package com.flab.auctionhub.user.application.request;
+
+import com.flab.auctionhub.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserCreateServiceRequest {
+
+    /**
+     * 회원 아이디
+     */
+    private String userId;
+    /**
+     * 회원 비밀번호
+     */
+    private String password;
+    /**
+     * 회원명
+     */
+    private String username;
+    /**
+     * 휴대폰 번호
+     */
+    private String phoneNumber;
+
+    public User toEntity(PasswordEncoder passwordEncoder) {
+        return User.builder()
+            .userId(this.getUserId())
+            .password(passwordEncoder.encode(this.getPassword()))
+            .username(this.getUsername())
+            .phoneNumber(this.getPhoneNumber())
+            .createdBy(this.getUsername())
+            .build();
+    }
+}

--- a/src/main/java/com/flab/auctionhub/user/application/request/UserLoginServiceRequest.java
+++ b/src/main/java/com/flab/auctionhub/user/application/request/UserLoginServiceRequest.java
@@ -1,0 +1,16 @@
+package com.flab.auctionhub.user.application.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserLoginServiceRequest {
+
+    private String userId;
+    private String password;
+}

--- a/src/main/java/com/flab/auctionhub/user/application/response/UserCreateResponse.java
+++ b/src/main/java/com/flab/auctionhub/user/application/response/UserCreateResponse.java
@@ -1,4 +1,4 @@
-package com.flab.auctionhub.user.dto.response;
+package com.flab.auctionhub.user.application.response;
 
 import com.flab.auctionhub.user.domain.User;
 import com.flab.auctionhub.user.domain.UserRoleType;

--- a/src/main/java/com/flab/auctionhub/user/application/response/UserLoginResponse.java
+++ b/src/main/java/com/flab/auctionhub/user/application/response/UserLoginResponse.java
@@ -1,4 +1,4 @@
-package com.flab.auctionhub.user.dto.response;
+package com.flab.auctionhub.user.application.response;
 
 import com.flab.auctionhub.user.domain.User;
 import com.flab.auctionhub.user.domain.UserRoleType;

--- a/src/main/java/com/flab/auctionhub/user/dao/UserMapper.java
+++ b/src/main/java/com/flab/auctionhub/user/dao/UserMapper.java
@@ -4,7 +4,6 @@ import com.flab.auctionhub.user.domain.User;
 import java.util.List;
 import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
 
 @Mapper // MyBatis의 매퍼 등록을 위한 어노테이션
 public interface UserMapper {

--- a/src/test/java/com/flab/auctionhub/user/api/UserControllerTest.java
+++ b/src/test/java/com/flab/auctionhub/user/api/UserControllerTest.java
@@ -11,10 +11,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.flab.auctionhub.user.application.UserService;
 import com.flab.auctionhub.user.domain.UserRoleType;
-import com.flab.auctionhub.user.dto.request.UserCreateRequest;
-import com.flab.auctionhub.user.dto.request.UserLoginRequest;
-import com.flab.auctionhub.user.dto.response.UserCreateResponse;
-import com.flab.auctionhub.user.dto.response.UserLoginResponse;
+import com.flab.auctionhub.user.api.request.UserCreateRequest;
+import com.flab.auctionhub.user.api.request.UserLoginRequest;
+import com.flab.auctionhub.user.application.response.UserCreateResponse;
+import com.flab.auctionhub.user.application.response.UserLoginResponse;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,7 +43,6 @@ class UserControllerTest {
     void createUser() throws Exception {
         // given
         UserCreateRequest user = CreateUserInfo1();
-        userService.createUser(user);
 
         // when // then
         mockMvc.perform(
@@ -64,7 +63,7 @@ class UserControllerTest {
             .username("testusername")
             .phoneNumber("010-1234-1234")
             .build();
-        userService.createUser(user);
+        userService.createUser(user.toServiceRequest());
 
         // when // then
         mockMvc.perform(
@@ -86,7 +85,7 @@ class UserControllerTest {
             .username("testusername")
             .phoneNumber("010-1234-1234")
             .build();
-        userService.createUser(user);
+        userService.createUser(user.toServiceRequest());
 
         // when // then
         mockMvc.perform(
@@ -108,7 +107,7 @@ class UserControllerTest {
             .password("testpassword")
             .phoneNumber("010-1234-1234")
             .build();
-        userService.createUser(user);
+        userService.createUser(user.toServiceRequest());
 
         // when // then
         mockMvc.perform(
@@ -130,7 +129,7 @@ class UserControllerTest {
             .password("testpassword")
             .username("testusername")
             .build();
-        userService.createUser(user);
+        userService.createUser(user.toServiceRequest());
 
         // when // then
         mockMvc.perform(
@@ -153,7 +152,7 @@ class UserControllerTest {
             .username("testusername")
             .phoneNumber("010-1234-1234")
             .build();
-        userService.createUser(user);
+        userService.createUser(user.toServiceRequest());
 
         // when // then
         mockMvc.perform(
@@ -176,7 +175,7 @@ class UserControllerTest {
             .username("testusername")
             .phoneNumber("010-1234-1234")
             .build();
-        userService.createUser(user);
+        userService.createUser(user.toServiceRequest());
 
         // when // then
         mockMvc.perform(
@@ -199,7 +198,7 @@ class UserControllerTest {
             .username("testusername")
             .phoneNumber("01012341234")
             .build();
-        userService.createUser(user);
+        userService.createUser(user.toServiceRequest());
 
         // when // then
         mockMvc.perform(
@@ -251,7 +250,7 @@ class UserControllerTest {
     void findById() throws Exception {
         // given
         UserCreateRequest userCreateRequest = CreateUserInfo1();
-        Long id = userService.createUser(userCreateRequest);
+        Long id = userService.createUser(userCreateRequest.toServiceRequest());
         UserCreateResponse userCreateResponse = new UserCreateResponse(
             userCreateRequest.getUserId(), userCreateRequest.getUsername(), UserRoleType.MEMBER,
             userCreateRequest.getPhoneNumber());
@@ -271,7 +270,7 @@ class UserControllerTest {
     void login() throws Exception {
         // given
         UserCreateRequest userCreateRequest = CreateUserInfo1();
-        userService.createUser(userCreateRequest);
+        userService.createUser(userCreateRequest.toServiceRequest());
         UserLoginRequest userLoginRequest = UserLoginRequest.builder()
             .userId(userCreateRequest.getUserId())
             .password(userCreateRequest.getPassword())
@@ -282,7 +281,7 @@ class UserControllerTest {
             userCreateRequest.getUsername(), UserRoleType.MEMBER,
             userCreateRequest.getPhoneNumber());
 
-        when(userService.login(userLoginRequest, session)).thenReturn(userLoginResponse);
+        when(userService.login(userLoginRequest.toServiceRequest(), session)).thenReturn(userLoginResponse);
 
         // when // then
         mockMvc.perform(

--- a/src/test/java/com/flab/auctionhub/user/application/UserServiceTest.java
+++ b/src/test/java/com/flab/auctionhub/user/application/UserServiceTest.java
@@ -4,11 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.groups.Tuple.tuple;
 
+import com.flab.auctionhub.user.application.request.UserCreateServiceRequest;
+import com.flab.auctionhub.user.application.request.UserLoginServiceRequest;
+import com.flab.auctionhub.user.application.response.UserCreateResponse;
+import com.flab.auctionhub.user.application.response.UserLoginResponse;
 import com.flab.auctionhub.user.domain.UserRoleType;
-import com.flab.auctionhub.user.dto.request.UserCreateRequest;
-import com.flab.auctionhub.user.dto.request.UserLoginRequest;
-import com.flab.auctionhub.user.dto.response.UserCreateResponse;
-import com.flab.auctionhub.user.dto.response.UserLoginResponse;
 import com.flab.auctionhub.user.exception.DuplicatedUserIdException;
 import com.flab.auctionhub.user.exception.UserNotFoundException;
 import java.util.List;
@@ -34,7 +34,7 @@ class UserServiceTest {
     @DisplayName("회원 1명을 생성하면 userId가 리턴된다.")
     void createUser() {
         // given
-        UserCreateRequest userCreateRequest = userCreateRequest("userId", "password", "username", "010-0000-0000");
+        UserCreateServiceRequest userCreateRequest = userCreateRequest("userId", "password", "username", "010-0000-0000");
 
         // when
         Long userId = userService.createUser(userCreateRequest);
@@ -47,9 +47,9 @@ class UserServiceTest {
     @DisplayName("중복된 회원을 생성하면 예외가 발생한다.")
     void checkUserIdDuplication() {
         // given
-        UserCreateRequest userCreateRequest1 = userCreateRequest("userId", "password", "username",
+        UserCreateServiceRequest userCreateRequest1 = userCreateRequest("userId", "password", "username",
             "010-0000-0000");
-        UserCreateRequest userCreateRequest2 = userCreateRequest("userId", "password", "username",
+        UserCreateServiceRequest userCreateRequest2 = userCreateRequest("userId", "password", "username",
             "010-0000-0000");
         userService.createUser(userCreateRequest1);
 
@@ -63,11 +63,11 @@ class UserServiceTest {
     @DisplayName("회원 3명을 생성하여 전체 회원을 조회한다.")
     void findAllUser() {
         // given
-        UserCreateRequest userCreateRequest1 = userCreateRequest("userId1", "password1", "username",
+        UserCreateServiceRequest userCreateRequest1 = userCreateRequest("userId1", "password1", "username",
             "010-0000-0000");
-        UserCreateRequest userCreateRequest2 = userCreateRequest("userId2", "password2", "username",
+        UserCreateServiceRequest userCreateRequest2 = userCreateRequest("userId2", "password2", "username",
             "010-1111-1111");
-        UserCreateRequest userCreateRequest3 = userCreateRequest("userId3", "password3", "username",
+        UserCreateServiceRequest userCreateRequest3 = userCreateRequest("userId3", "password3", "username",
             "010-2222-2222");
         userService.createUser(userCreateRequest1);
         userService.createUser(userCreateRequest2);
@@ -93,7 +93,7 @@ class UserServiceTest {
     @DisplayName("회원을 등록하고 PK값인 id를 이용하여 회원을 조회한다.")
     void findById() {
         // given
-        UserCreateRequest userCreateRequest = userCreateRequest("userId1", "password1", "username",
+        UserCreateServiceRequest userCreateRequest = userCreateRequest("userId1", "password1", "username",
             "010-0000-0000");
         Long userCreateRequestId = userService.createUser(userCreateRequest);
 
@@ -127,9 +127,9 @@ class UserServiceTest {
         ]
         """) // JSON 형식의 데이터를 매개변수로 제공하는데 사용되는 어노테이션
     @DisplayName("회원을 등록하고 로그인한다.")
-    void login(UserLoginRequest userLoginRequest) {
+    void login(UserLoginServiceRequest userLoginRequest) {
         // given
-        UserCreateRequest userCreateRequest = userCreateRequest("userId", "password", "username",
+        UserCreateServiceRequest userCreateRequest = userCreateRequest("userId", "password", "username",
             "010-0000-0000");
         userService.createUser(userCreateRequest);
         MockHttpSession session = new MockHttpSession();
@@ -141,9 +141,9 @@ class UserServiceTest {
         assertThat(userLoginResponse.getUserId()).isEqualTo(userCreateRequest.getUserId());
     }
 
-    private UserCreateRequest userCreateRequest(String userId, String password, String username,
+    private UserCreateServiceRequest userCreateRequest(String userId, String password, String username,
         String phoneNumber) {
-        return UserCreateRequest.builder()
+        return UserCreateServiceRequest.builder()
             .userId(userId)
             .password(password)
             .username(username)


### PR DESCRIPTION
1. 이슈 번호 : [#25  ]
2. 작업 내용
    - 회원 도메인에서 컨트롤러와 서비스 DTO를 분리한다.
    - @transactional readonly 주석 추가
    - 코드 리팩토링
3. 체크리스트
    - DTO 분리 함으로써 리팩토링이 잘 되었는지