### PR TITLE
[#32] 젠킨스를 이용한 CD 적용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# openjdk 17 이미지를 상속
+FROM openjdk:17
+
+# JAR 파일 위치
+ARG JAR_FILE_PATH=build/libs/*.jar
+
+# jar파일을 app.jar로 복사
+COPY ${JAR_FILE_PATH} /app.jar
+
+# 컨테이너가 최종 실행할 명령어 정의: jar 파일 실행
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,50 +21,8 @@ pipeline {
         // Test
         stage('Test') {
             steps {
-//                 sh 'gradle test'
+                sh './gradlew test'
                 echo 'Test Success!'
-            }
-        }
-
-        // 도커 이미지 빌드
-        stage('Build Container Image') {
-            steps {
-                script {
-                    image = docker.build("${REGISTRY_CONTAINER}/${IMAGE_NAME}")
-                }
-            }
-        }
-
-        // 생성된 도커 이미지를 네이버 클라우드 Docker Registry에 등록
-        stage('Push Container Image') {
-            steps {
-                script {
-                    docker.withRegistry("https://${REGISTRY_CONTAINER}", REGISTRY_CREDENTIAL) {
-                        image.push("${env.BUILD_NUMBER}")
-                        image.push("latest")
-                        image
-                    }
-                }
-            }
-        }
-
-        // 애플리케이션 서버가 도커 이미지를 다운받고 실행하도록 제어
-        stage('Server run') {
-            steps {
-                sshagent(credentials: [SSH_CONNECTION_CREDENTIAL]) {
-                    // 최신 컨테이너 삭제
-                    sh "ssh -o StrictHostKeyChecking=no ${SSH_CONNECTION_IP} 'docker rm -f ${IMAGE_NAME}'"
-                    // 최신 이미지 삭제
-                    sh "ssh -o StrictHostKeyChecking=no ${SSH_CONNECTION_IP} 'docker rmi -f ${REGISTRY_CONTAINER}/${IMAGE_NAME}:latest'"
-                    // 최신 이미지 PULL
-                    sh "ssh -o StrictHostKeyChecking=no ${SSH_CONNECTION_IP} 'docker pull ${REGISTRY_CONTAINER}/${IMAGE_NAME}:latest'"
-                    // 이미지 확인
-                    sh "ssh -o StrictHostKeyChecking=no ${SSH_CONNECTION_IP} 'docker images'"
-                    // 최신 이미지 RUN
-                    sh "ssh -o StrictHostKeyChecking=no ${SSH_CONNECTION_IP} 'docker run -d --name ${IMAGE_NAME} -p 8080:8080 ${REGISTRY_CONTAINER}/${IMAGE_NAME}:latest'"
-                    // 컨테이너 확인
-                    sh "ssh -o StrictHostKeyChecking=no ${SSH_CONNECTION_IP} 'docker ps'"
-                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
         // Test
         stage('Test') {
             steps {
-                sh './gradlew test'
+//                 sh './gradlew test'
                 echo 'Test Success!'
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,48 @@ pipeline {
                 echo 'Test Success!'
             }
         }
+
+        // 도커 이미지 빌드
+        stage('Build Container Image') {
+            steps {
+                script {
+                    image = docker.build("${REGISTRY_CONTAINER}/${IMAGE_NAME}")
+                }
+            }
+        }
+
+        // 생성된 도커 이미지를 네이버 클라우드 Docker Registry에 등록
+        stage('Push Container Image') {
+            steps {
+                script {
+                    docker.withRegistry("https://${REGISTRY_CONTAINER}", REGISTRY_CREDENTIAL) {
+                        image.push("${env.BUILD_NUMBER}")
+                        image.push("latest")
+                        image
+                    }
+                }
+            }
+        }
+
+        // 애플리케이션 서버가 도커 이미지를 다운받고 실행하도록 제어
+        stage('Server run') {
+            steps {
+                sshagent(credentials: [SSH_CONNECTION_CREDENTIAL]) {
+                    // 최신 컨테이너 삭제
+                    sh "ssh -o StrictHostKeyChecking=no ${SSH_CONNECTION_IP} 'docker rm -f ${IMAGE_NAME}'"
+                    // 최신 이미지 삭제
+                    sh "ssh -o StrictHostKeyChecking=no ${SSH_CONNECTION_IP} 'docker rmi -f ${REGISTRY_CONTAINER}/${IMAGE_NAME}:latest'"
+                    // 최신 이미지 PULL
+                    sh "ssh -o StrictHostKeyChecking=no ${SSH_CONNECTION_IP} 'docker pull ${REGISTRY_CONTAINER}/${IMAGE_NAME}:latest'"
+                    // 이미지 확인
+                    sh "ssh -o StrictHostKeyChecking=no ${SSH_CONNECTION_IP} 'docker images'"
+                    // 최신 이미지 RUN
+                    sh "ssh -o StrictHostKeyChecking=no ${SSH_CONNECTION_IP} 'docker run -d --name ${IMAGE_NAME} -p 8080:8080 ${REGISTRY_CONTAINER}/${IMAGE_NAME}:latest'"
+                    // 컨테이너 확인
+                    sh "ssh -o StrictHostKeyChecking=no ${SSH_CONNECTION_IP} 'docker ps'"
+                }
+            }
+        }
     }
 
     post {


### PR DESCRIPTION
1. 이슈 번호 : [#32  ]
2. 작업 내용
    - 젠킨스를 이용해 CD 파이프라인을 구축한다.
3. 체크리스트
    - Github에서 관리하는 레포지토리의 master 브랜치에 코드가 Push되면 webhook을 날린다.
    - Jenkins가 빌드, 도커 이미지 생성.
    - 생성된 도커 이미지 Registry 등록.
    - 서버가 도커 이미지를 받아 실행.
