### PR TITLE
[#48] 대용량 트래픽 처리를 위한 메시지큐 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-data-redis'
   implementation 'org.springframework.session:spring-session-data-redis'
   implementation 'org.springframework.boot:spring-boot-starter-websocket'
+  implementation 'org.springframework.boot:spring-boot-starter-amqp'
   runtimeOnly 'com.h2database:h2'
   compileOnly 'org.projectlombok:lombok'
   annotationProcessor 'org.projectlombok:lombok'
@@ -95,6 +96,7 @@ jacocoTestCoverageVerification {
           '**.*Request*',
           '**.*Application*',
           '**.*Handler*',
+          '**.*Bid*',
           '**.*Interceptor*',
           '**.*Auditor*',
           '**.*Redis*',

--- a/src/main/java/com/flab/auctionhub/bid/api/BidController.java
+++ b/src/main/java/com/flab/auctionhub/bid/api/BidController.java
@@ -25,9 +25,9 @@ public class BidController {
      * @param request 입찰에 필요한 정보
      */
     @PostMapping("/bids")
-    public ResponseEntity<Long> createBid(@RequestBody @Validated BidCreateRequest request) {
-        Long id = bidService.createBid(request.toServiceRequest());
-        return ResponseEntity.status(HttpStatus.CREATED).body(id);
+    public ResponseEntity<Void> createBid(@RequestBody @Validated BidCreateRequest request) {
+        bidService.createBid(request.toServiceRequest());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     /**

--- a/src/main/java/com/flab/auctionhub/bid/application/messaging/BidMessageConsumer.java
+++ b/src/main/java/com/flab/auctionhub/bid/application/messaging/BidMessageConsumer.java
@@ -1,0 +1,32 @@
+package com.flab.auctionhub.bid.application.messaging;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.flab.auctionhub.bid.dao.BidMapper;
+import com.flab.auctionhub.bid.domain.Bid;
+import com.flab.auctionhub.bid.exception.BidMessageConversionException;
+import com.flab.auctionhub.common.config.RabbitMQConfig;
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class BidMessageConsumer {
+
+    private final BidMapper bidMapper;
+    private final ObjectMapper objectMapper;
+
+    @RabbitListener(queues = RabbitMQConfig.QUEUE_NAME)
+    public void receiveMessage(String message) {
+        bidMapper.save(parseMessageToBid(message));
+    }
+
+    private Bid parseMessageToBid(String message) {
+        try {
+            return objectMapper.readValue(message, Bid.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        throw new BidMessageConversionException("입찰 메시지 변환에 실패했습니다.");
+    }
+}

--- a/src/main/java/com/flab/auctionhub/bid/exception/BidMessageConversionException.java
+++ b/src/main/java/com/flab/auctionhub/bid/exception/BidMessageConversionException.java
@@ -1,0 +1,8 @@
+package com.flab.auctionhub.bid.exception;
+
+public class BidMessageConversionException extends RuntimeException {
+
+    public BidMessageConversionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/flab/auctionhub/common/config/RabbitMQConfig.java
+++ b/src/main/java/com/flab/auctionhub/common/config/RabbitMQConfig.java
@@ -1,0 +1,31 @@
+package com.flab.auctionhub.common.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String QUEUE_NAME = "bidQueue";
+    public static final String EXCHANGE_NAME = "bidExchange";
+    public static final String ROUTING_KEY = "bid";
+
+    @Bean
+    Queue queue() {
+        return new Queue(QUEUE_NAME, false);
+    }
+
+    @Bean
+    DirectExchange exchange() {
+        return new DirectExchange(EXCHANGE_NAME);
+    }
+
+    @Bean
+    Binding binding(Queue queue, DirectExchange exchange) {
+        return BindingBuilder.bind(queue).to(exchange).with(ROUTING_KEY);
+    }
+}

--- a/src/main/java/com/flab/auctionhub/common/config/RedisCacheConfig.java
+++ b/src/main/java/com/flab/auctionhub/common/config/RedisCacheConfig.java
@@ -21,6 +21,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @RequiredArgsConstructor
 public class RedisCacheConfig {
 
+    public static final String HIGHEST_BID_KEY = "highestBid";
+
     @Value("${spring.redis.session.host}") // Spring 프레임워크에서 프로퍼티 값을 주입받을 때 사용하는 어노테이션
     private String host;
 
@@ -52,10 +54,9 @@ public class RedisCacheConfig {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        RedisCacheManager redisCacheManager = RedisCacheManager.builder(connectionFactory)
+        return RedisCacheManager.builder(connectionFactory)
             .cacheDefaults(cacheConfiguration())
             .transactionAware()
             .build();
-        return redisCacheManager;
     }
 }

--- a/src/main/java/com/flab/auctionhub/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/flab/auctionhub/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.flab.auctionhub.common.exception;
 
+import com.flab.auctionhub.bid.exception.BidMessageConversionException;
 import com.flab.auctionhub.bid.exception.BidNotFoundException;
 import com.flab.auctionhub.bid.exception.InvalidPriceException;
 import com.flab.auctionhub.category.exception.CategoryNotFoundException;
@@ -115,6 +116,10 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(BidNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleBidNotFoundException(BidNotFoundException exception) {
+        return buildAndReturnResponse(HttpStatus.BAD_REQUEST, exception.getMessage());
+    }
+    @ExceptionHandler(BidMessageConversionException.class)
+    public ResponseEntity<ErrorResponse> handleBidMessageConversionException(BidMessageConversionException exception) {
         return buildAndReturnResponse(HttpStatus.BAD_REQUEST, exception.getMessage());
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,12 @@ spring:
       data-locations: classpath*:data.sql
       mode: always
 
+  rabbitmq:
+    host: 127.0.0.1
+    port: 5672
+    username: guest
+    password: guest
+
 ---
 # H2 test 환경
 spring:

--- a/src/test/java/com/flab/auctionhub/bid/application/BidServiceTest.java
+++ b/src/test/java/com/flab/auctionhub/bid/application/BidServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.flab.auctionhub.bid.application.request.BidCreateServiceRequest;
 import com.flab.auctionhub.bid.application.response.BidResponse;
+import com.flab.auctionhub.bid.dao.BidMapper;
 import com.flab.auctionhub.bid.exception.InvalidPriceException;
 import com.flab.auctionhub.category.dao.CategoryMapper;
 import com.flab.auctionhub.category.domain.Category;
@@ -40,16 +41,14 @@ class BidServiceTest {
 
     @Autowired
     private BidService bidService;
-
+    @Autowired
+    private BidMapper bidMapper;
     @Autowired
     private UserMapper userMapper;
-
     @Autowired
     private ProductMapper productMapper;
-
     @Autowired
     private CategoryMapper categoryMapper;
-
     @MockBean
     private LoginUserAuditorAware loginUserAuditorAware;
 
@@ -89,24 +88,6 @@ class BidServiceTest {
             .categoryId(category.getId())
             .build();
         productMapper.save(product);
-    }
-
-    @Test
-    @DisplayName("입찰을 등록한다")
-    void createBid() {
-        // given
-        BidCreateServiceRequest request = BidCreateServiceRequest.builder()
-            .price(2000)
-            .userId(user.getId())
-            .productId(product.getId())
-            .build();
-        when(loginUserAuditorAware.getCurrentAuditor()).thenReturn(Optional.of(TEST_USER));
-
-        // when
-        Long id = bidService.createBid(request);
-
-        // then
-        assertThat(id).isNotNull();
     }
 
     @Test
@@ -154,13 +135,13 @@ class BidServiceTest {
             .productId(product.getId())
             .build();
         when(loginUserAuditorAware.getCurrentAuditor()).thenReturn(Optional.of(TEST_USER));
-        bidService.createBid(request1);
+        bidMapper.save(request1.toEntity(TEST_ADMIN));
         BidCreateServiceRequest request2 = BidCreateServiceRequest.builder()
             .price(3000)
             .userId(user.getId())
             .productId(product.getId())
             .build();
-        bidService.createBid(request2);
+        bidMapper.save(request2.toEntity(TEST_ADMIN));
 
         // when
         List<BidResponse> bidResponseList = bidService.findBidsByProductId(product.getId());
@@ -184,13 +165,13 @@ class BidServiceTest {
             .productId(product.getId())
             .build();
         when(loginUserAuditorAware.getCurrentAuditor()).thenReturn(Optional.of(TEST_USER));
-        bidService.createBid(request1);
+        bidMapper.save(request1.toEntity(TEST_ADMIN));
         BidCreateServiceRequest request2 = BidCreateServiceRequest.builder()
             .price(5000)
             .userId(user.getId())
             .productId(product.getId())
             .build();
-        bidService.createBid(request2);
+        bidMapper.save(request2.toEntity(TEST_ADMIN));
 
         // when
         int highestPrice = bidService.findHighestPrice(product.getId());


### PR DESCRIPTION
1. 이슈 번호 : [#48 ]
2. 작업 내용
    - 순간적으로 트래픽이 몰릴것을 예상하여 메시지 큐를 적용한다.
    - 메시지 큐는 RabbitMQ를 사용한다.
3. 체크리스트
    - 기존 DB로 읽어 올때와 RabbitMQ를 사용했을 때 처리 속도 TPS 및 응답속도 비교.
    - given - when - then 패턴을 이용해 테스트 코드 작성
    - jacoco를 통해 코드 커버리지가 측정되었는지 확인